### PR TITLE
Prevent quoting outputs

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -34,7 +34,7 @@ aws_cloudformation_output() {
   jq_query+='select(.OutputKey == "'
   jq_query+=${OUTPUT_NAME}
   jq_query+='") | .OutputValue'
-  "${aws_command[@]}" | jq "$jq_query"
+  "${aws_command[@]}" | jq -r "$jq_query"
 }
 
 set_output_env() {

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-aws_command=("aws" "cloudformation" "describe-stacks")
+describe_command=("aws" "cloudformation" "describe-stacks")
 jq_query='.Stacks[].Outputs[] | '
 
 BUILDKITE_PLUGIN_CLOUDFORMATION_OUTPUT_OUTPUT=${BUILDKITE_PLUGIN_CLOUDFORMATION_OUTPUT_OUTPUT:-''}
@@ -44,9 +44,9 @@ set_output_env() {
 
 if [[ "${#CF_OUTPUTS[@]}" -gt 0 ]] ; then
   for element in ${CF_OUTPUTS[*]} ; do
-    unset STACK_NAME OUTPUT_NAME AWS_REGION
+    unset STACK_NAME OUTPUT_NAME AWS_REGION aws_command
     extract_options
-    aws_command+=("--stack-name" "${STACK_NAME}" "--region" "${AWS_REGION}")
+    aws_command=("${describe_command[@]}" "--stack-name" "${STACK_NAME}" "--region" "${AWS_REGION}")
     OUTPUT_RESULT=$(aws_cloudformation_output)
     set_output_env
     echo "Set ${OUTPUT_KEY} to ${OUTPUT_RESULT}"

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -20,9 +20,9 @@ setup()
     "cloudformation describe-stacks --stack-name bcloud --region bregion : cat tests/bresults.json" \
     "cloudformation describe-stacks --stack-name ccloud --region cregion : cat tests/cresults.json"
   stub jq \
-    "'.Stacks[].Outputs[] | select(.OutputKey == \"a-output\") | .OutputValue' : echo look_at_me" \
-    "'.Stacks[].Outputs[] | select(.OutputKey == \"b-output\") | .OutputValue' : echo look_at_b" \
-    "'.Stacks[].Outputs[] | select(.OutputKey == \"c-output\") | .OutputValue' : echo look_at_c"
+    "-r '.Stacks[].Outputs[] | select(.OutputKey == \"a-output\") | .OutputValue' : echo look_at_me" \
+    "-r '.Stacks[].Outputs[] | select(.OutputKey == \"b-output\") | .OutputValue' : echo look_at_b" \
+    "-r '.Stacks[].Outputs[] | select(.OutputKey == \"c-output\") | .OutputValue' : echo look_at_c"
 
   run "$PWD/hooks/pre-command"
   assert_success

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -30,7 +30,7 @@ setup()
   assert_output --partial "Set BCLOUD_B_OUTPUT to look_at_b"
   assert_output --partial "Set CCLOUD_C_OUTPUT to look_at_c"
 
-#  unstub aws
+  unstub aws
   unstub jq
 }
 


### PR DESCRIPTION
When setting the environment variable the plugin is including quotes, because JQ includes the quotes.

```
OUTPUT_RESULT='"output value"'
```

Use the raw flag to prevent that.
Unfortunately the default behaviour for buildkite plugins is to stub out JQ, which IMO leads to problems like this. But since JQ is not installed in the container we use to test we can't change that for now.

I also found and fixed a bug where multiple output values were not working as expected.